### PR TITLE
Make it possible to retry jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+Job retries!
 
 ## [0.4.4] - 2021-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [Unreleased]
 
-Job retries!
+
+## [0.5.0] - 2021-08-07
+
+- Job retries! The jobs now have ids, so you can follow the job and it's retries from the log. 
+- Quite a lot has changed internally, so if you were not using the Belated::Queue class to enqueue your jobs, you will need to update your code.
 
 ## [0.4.4] - 2021-08-07
 

--- a/lib/belated.rb
+++ b/lib/belated.rb
@@ -156,12 +156,16 @@ class Belated
     @@queue.clear
   end
 
+  def self.fetch_job
+    @@queue.pop
+  end
+  
   def job_list
     @@queue
   end
 
-  def self.fetch_job
-    @@queue.pop
+  def self.job_list
+    @@queue
   end
 
   class Error < StandardError; end

--- a/lib/belated.rb
+++ b/lib/belated.rb
@@ -4,6 +4,7 @@ require_relative 'belated/logging'
 require_relative 'belated/version'
 require_relative 'belated/worker'
 require 'belated/client'
+require 'belated/job_wrapper'
 require 'belated/queue'
 require 'drb'
 require 'dry-configurable'
@@ -91,9 +92,9 @@ class Belated
     log 'starting future jobs thread'
     loop do
       @@queue.future_jobs.each_with_index do |job, i|
-        if job[:at] <= Time.now.utc
-          log @@queue.future_jobs.delete_at(i)
-          @@queue.push(job[:klass])
+        if job.at <= Time.now.utc
+          log "Deleting #{@@queue.future_jobs.delete_at(i)} from future jobs"
+          @@queue.push(job)
         end
       end
       sleep 0.01

--- a/lib/belated.rb
+++ b/lib/belated.rb
@@ -159,7 +159,7 @@ class Belated
   def self.fetch_job
     @@queue.pop
   end
-  
+
   def job_list
     @@queue
   end

--- a/lib/belated/job_wrapper.rb
+++ b/lib/belated/job_wrapper.rb
@@ -4,7 +4,7 @@ class Belated
   class JobWrapper
     attr_accessor :retries, :max_retries, :id, :job, :at
 
-    def initialize(max_retries: 5, job:, at: nil)
+    def initialize(job:, max_retries: 5, at: nil)
       self.retries = 0
       self.max_retries = max_retries
       self.id = SecureRandom.uuid

--- a/lib/belated/job_wrapper.rb
+++ b/lib/belated/job_wrapper.rb
@@ -26,15 +26,19 @@ class Belated
       when Interrupt, SignalException
         raise e
       else
-        self.retries += 1
-        unless retries > max_retries
-          self.at = Time.now.utc + (retries.next ** 4)
-          log "Job #{id} failed, retrying at #{at}"
-          Belated.job_list.push(self)
-        end
-        "Error while executing job, #{e.inspect}"
+        retry_job
+        "Error while executing job, #{e.inspect}. Retry #{retries} of #{max_retries}"
       end
     end
     # rubocop:enable Lint/RescueException
+
+    def retry_job
+      self.retries += 1
+      return if retries > max_retries
+
+      self.at = Time.now.utc + (retries.next**4)
+      log "Job #{id} failed, retrying at #{at}"
+      Belated.job_list.push(self)
+    end
   end
 end

--- a/lib/belated/job_wrapper.rb
+++ b/lib/belated/job_wrapper.rb
@@ -1,0 +1,15 @@
+require 'securerandom'
+
+class Belated
+  class JobWrapper
+    attr_accessor :retries, :max_retries, :id, :job, :at
+
+    def initialize(max_retries: 5, job:, at: nil)
+      self.retries = 0
+      self.max_retries = max_retries
+      self.id = SecureRandom.uuid
+      self.job = job
+      self.at = at
+    end
+  end
+end

--- a/lib/belated/job_wrapper.rb
+++ b/lib/belated/job_wrapper.rb
@@ -1,7 +1,9 @@
 require 'securerandom'
+require_relative 'logging'
 
 class Belated
   class JobWrapper
+    include Logging
     attr_accessor :retries, :max_retries, :id, :job, :at
 
     def initialize(job:, max_retries: 5, at: nil)
@@ -11,5 +13,28 @@ class Belated
       self.job = job
       self.at = at
     end
+
+    # rubocop:disable Lint/RescueException
+    def perform
+      if job.respond_to?(:call)
+        job.call
+      else
+        job.perform
+      end
+    rescue Exception => e
+      case e.class
+      when Interrupt, SignalException
+        raise e
+      else
+        self.retries += 1
+        unless retries > max_retries
+          self.at = Time.now.utc + (retries.next ** 4)
+          log "Job #{id} failed, retrying at #{at}"
+          Belated.job_list.push(self)
+        end
+        "Error while executing job, #{e.inspect}"
+      end
+    end
+    # rubocop:enable Lint/RescueException
   end
 end

--- a/lib/belated/worker.rb
+++ b/lib/belated/worker.rb
@@ -19,29 +19,8 @@ class Belated
         break if job == :shutdown
 
         log "Worker #{@number} got job: #{job.inspect}"
-        if job.respond_to?(:job)
-          log call_job(job.job)
-        else
-          log call_job(job)
-        end
-      end
-    end
-
-    # rubocop:disable Lint/RescueException
-    def call_job(job)
-      if job.respond_to?(:call)
-        job.call
-      else
         job.perform
       end
-    rescue Exception => e
-      case e.class
-      when Interrupt, SignalException
-        raise e
-      else
-        "Error while executing job, #{e.inspect}"
-      end
     end
-    # rubocop:enable Lint/RescueException
   end
 end

--- a/lib/belated/worker.rb
+++ b/lib/belated/worker.rb
@@ -20,7 +20,7 @@ class Belated
 
         log "Worker #{@number} got job: #{job.inspect}"
         if job.respond_to?(:job)
-          log call_job(job.job) 
+          log call_job(job.job)
         else
           log call_job(job)
         end

--- a/lib/belated/worker.rb
+++ b/lib/belated/worker.rb
@@ -18,7 +18,12 @@ class Belated
 
         break if job == :shutdown
 
-        log call_job(job)
+        log "Worker #{@number} got job: #{job.inspect}"
+        if job.respond_to?(:job)
+          log call_job(job.job) 
+        else
+          log call_job(job)
+        end
       end
     end
 
@@ -34,7 +39,7 @@ class Belated
       when Interrupt, SignalException
         raise e
       else
-        e.inspect
+        "Error while executing job, #{e.inspect}"
       end
     end
     # rubocop:enable Lint/RescueException

--- a/spec/belated/client_spec.rb
+++ b/spec/belated/client_spec.rb
@@ -54,12 +54,18 @@ RSpec.describe Belated::Client do
       now = Time.now.utc
       perform_at = now + 0.5
       @client.perform_belated(
-        proc { User.create!(name: 'Diana!') },
-        at: perform_at
+        Belated::JobWrapper.new(
+          job: proc { User.create!(name: 'Diana!') },
+          at: perform_at
+        )
       )
       expect(User.find_by(name: 'Diana!')).to be_nil
-      sleep 0.6
+      sleep 1.63
       expect(User.find_by(name: 'Diana!')).to be_a User
+    end
+
+    it 'retries the jobs' do
+      
     end
   end
 end

--- a/spec/belated/client_spec.rb
+++ b/spec/belated/client_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Belated::Client do
     end
 
     it 'retries the jobs' do
-      
+      'To be continued'
     end
   end
 end

--- a/spec/belated/job_wrapper_spec.rb
+++ b/spec/belated/job_wrapper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Belated::JobWrapper do
   describe '#perform' do
     it 'should retry the job until it succeeds' do
       subject.job = proc { raise 'error' }
-      expect{ 
+      expect {
         subject.perform
       }.to change { subject.retries }.from(0).to(1)
       expect(Belated.job_list.future_jobs.empty?).to be_falsey

--- a/spec/belated/job_wrapper_spec.rb
+++ b/spec/belated/job_wrapper_spec.rb
@@ -7,4 +7,14 @@ RSpec.describe Belated::JobWrapper do
       expect(subject.id).not_to be_nil
     end
   end
+
+  describe '#perform' do
+    it 'should retry the job until it succeeds' do
+      subject.job = proc { raise 'error' }
+      expect{ 
+        subject.perform
+      }.to change { subject.retries }.from(0).to(1)
+      expect(Belated.job_list.future_jobs.empty?).to be_falsey
+    end
+  end
 end

--- a/spec/belated/job_wrapper_spec.rb
+++ b/spec/belated/job_wrapper_spec.rb
@@ -1,8 +1,6 @@
-
-
 RSpec.describe Belated::JobWrapper do
-  subject = described_class.new(max_retries: 1, job: proc { 1/ 2})
-  
+  subject = described_class.new(max_retries: 1, job: proc { 1 / 2 })
+
   describe '#initialize' do
     it 'should have an option for retry count' do
       expect(subject.max_retries).to eq(1)

--- a/spec/belated/job_wrapper_spec.rb
+++ b/spec/belated/job_wrapper_spec.rb
@@ -1,0 +1,12 @@
+
+
+RSpec.describe Belated::JobWrapper do
+  subject = described_class.new(max_retries: 1, job: proc { 1/ 2})
+  
+  describe '#initialize' do
+    it 'should have an option for retry count' do
+      expect(subject.max_retries).to eq(1)
+      expect(subject.id).not_to be_nil
+    end
+  end
+end

--- a/spec/belated/queue_spec.rb
+++ b/spec/belated/queue_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Belated::Queue do
   it 'logs the completed jobs' do
-    queue = Belated::Queue.new
+    # queue = Belated::Queue.new
   end
 end

--- a/spec/belated/queue_spec.rb
+++ b/spec/belated/queue_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe Belated::Queue do
+  it 'logs the completed jobs' do
+    queue = Belated::Queue.new
+  end
+end

--- a/spec/belated_spec.rb
+++ b/spec/belated_spec.rb
@@ -50,8 +50,9 @@ RSpec.describe Belated do
           @worker.job_list.push(
             Belated::JobWrapper.new(
               job: DumDum.new(sleep: 1),
-              at: Time.now.utc + 500)
+              at: Time.now.utc + 500
             )
+          )
         end
         @worker.stop_workers
         @worker.reload

--- a/spec/belated_spec.rb
+++ b/spec/belated_spec.rb
@@ -33,8 +33,12 @@ RSpec.describe Belated do
       end
 
       it 'remembers the jobs it has enqued even if restarted' do
-        5.times do
-          @worker.job_list.push(DumDum.new(sleep: 1))
+        8.times do
+          @worker.job_list.push(
+            Belated::JobWrapper.new(
+              job: DumDum.new(sleep: 10)
+            )
+          )
         end
         @worker.stop_workers
         @worker.reload
@@ -43,7 +47,11 @@ RSpec.describe Belated do
 
       it 'remembers future jobs it has enqued even if restarted' do
         5.times do
-          @worker.job_list.push(DumDum.new(sleep: 1), at: Time.now + 500)
+          @worker.job_list.push(
+            Belated::JobWrapper.new(
+              job: DumDum.new(sleep: 1),
+              at: Time.now.utc + 500)
+            )
         end
         @worker.stop_workers
         @worker.reload
@@ -65,14 +73,18 @@ RSpec.describe Belated do
     it 'will not crash with syntax errors' do
       expect {
         @worker.job_list.push(
-          proc { raise SyntaxError }
+          Belated::JobWrapper.new(
+            job: proc { raise SyntaxError }
+          )
         )
         sleep 0.01
       }.not_to raise_error
     end
 
     it 'allows you to run code in the background' do
-      @worker.job_list.push(proc { puts 'hello' })
+      @worker.job_list.push(
+        Belated::JobWrapper.new(job: proc { puts 'hello' })
+      )
       expect(@worker.job_list.length).to eq 1
       sleep 0.02
       expect(@worker.job_list.empty?).to be_truthy

--- a/spec/druby_job_spec.rb
+++ b/spec/druby_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Belated do
       Belated.config.workers = 1
       thread = Thread.new { Belated.new }
       dummy = DummyWorker.new
-      dummy.queue.push(DumDum.new)
+      dummy.queue.push(Belated::JobWrapper.new(job: DumDum.new))
       sleep 0.05
       expect(dummy.queue.empty?).to be_truthy
       thread.kill

--- a/spec/klass_spec.rb
+++ b/spec/klass_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Belated do
     end
     worker = Belated.new
     5.times do
-      worker.job_list.push(DumDum.new)
+      worker.job_list.push(
+        Belated::JobWrapper.new(job: DumDum.new)
+      )
     end
     sleep 0.2
     expect(worker.job_list.length).to eq 0

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -18,10 +18,12 @@ RSpec.describe Belated do
   it 'Runs the code in the background, so the count does not change immediately' do
     expect {
       @dummy.queue.push(
-        proc do
-          sleep 0.1
-          User.create!(name: 'David')
-        end
+        Belated::JobWrapper.new(job:
+          proc do
+            sleep 0.1
+            User.create!(name: 'David')
+          end
+        )
       )
     }.to change { User.where(name: 'David').count }.by(0)
     expect {

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe Belated do
           proc do
             sleep 0.1
             User.create!(name: 'David')
-          end
-        )
+          end)
       )
     }.to change { User.where(name: 'David').count }.by(0)
     expect {


### PR DESCRIPTION
Adds a `JobWrapper` class that is responsible for holding the state of the job. 
It adds an id to the job, knows what time the job should be executed at, and takes care of retries. 

New option for the Client: `max_retries`. 